### PR TITLE
feat: add backend abstraction for inference server

### DIFF
--- a/src/prime_rl/inference/backends/base.py
+++ b/src/prime_rl/inference/backends/base.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+
+from prime_rl.inference.config import InferenceConfig
+
+
+class BaseBackend(ABC):
+    @abstractmethod
+    def startup(self, config: InferenceConfig) -> None: ...
+
+    @abstractmethod
+    async def update_weights(self, path: str) -> None: ...
+
+    @abstractmethod
+    async def reload_weights(self) -> None: ...
+
+    @abstractmethod
+    async def flush_cache(self) -> None: ...

--- a/src/prime_rl/inference/config.py
+++ b/src/prime_rl/inference/config.py
@@ -6,6 +6,8 @@ from pydantic import Field
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings, get_all_fields
 from prime_rl.utils.utils import rgetattr, rsetattr
 
+ServerType = Literal["vllm"]
+
 # TODO: Set thinking/ solution budget
 
 
@@ -14,6 +16,7 @@ class ServerConfig(BaseConfig):
 
     host: Annotated[str | None, Field(description="The host to bind to.")] = None
     port: Annotated[int, Field(description="The port to bind to.")] = 8000
+    server_type: Annotated[ServerType, Field(description="Backend type.")] = "vllm"
 
 
 class ParallelConfig(BaseConfig):
@@ -84,7 +87,6 @@ class ModelConfig(BaseConfig):
     ] = False
 
     tool_call_parser: Annotated[
-
         str,
         Field(
             description="The tool call parser to use. Passed to vLLM as `--tool-call-parser`",
@@ -123,7 +125,7 @@ class InferenceConfig(BaseSettings):
             "model.enforce_eager": "enforce_eager",
             "model.trust_remote_code": "trust_remote_code",
             "model.enable_auto_tool_choice": "enable_auto_tool_choice",  # requires underscores (unlike on CLI)
-            "model.tool_call_parser": "tool_call_parser",                # requires underscores (unlike on CLI)
+            "model.tool_call_parser": "tool_call_parser",  # requires underscores (unlike on CLI)
             "parallel.tp": "tensor_parallel_size",
             "parallel.dp": "data_parallel_size",
         }

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -1,11 +1,18 @@
+from prime_rl.inference.backends.vllm import VLLMBackend
 from prime_rl.inference.config import InferenceConfig
-from prime_rl.inference.vllm.server import server
 from prime_rl.utils.pydantic_config import parse_argv
+
+BACKENDS = {"vllm": VLLMBackend}
 
 
 def main():
     config = parse_argv(InferenceConfig, allow_extras=True)
-    server(config, vllm_args=config.get_unknown_args())
+    server_type = config.server.server_type
+    backend_cls = BACKENDS.get(server_type)
+    if backend_cls is None:
+        raise ValueError(f"Unsupported server type: {server_type}")
+    backend = backend_cls()
+    backend.startup(config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add BaseBackend interface for inference servers
- implement VLLMBackend and move vLLM server logic
- let inference server pick backend via `server_type`

## Testing
- `uv run pre-commit run --files src/prime_rl/inference/backends/base.py src/prime_rl/inference/backends/vllm.py src/prime_rl/inference/config.py src/prime_rl/inference/server.py`
- `uv run pytest -q` *(fails: RuntimeError: vLLM server did not become healthy within timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c58cd6bee0832e88b5b94ada7050fd