### PR TITLE
Add sglang config translation and extra inference flags

### DIFF
--- a/src/prime_rl/inference/backends/sglang.py
+++ b/src/prime_rl/inference/backends/sglang.py
@@ -4,7 +4,7 @@ from typing import Any
 import httpx
 from fastapi import HTTPException, Request
 from fastapi.routing import APIRoute
-from sglang.srt.entrypoints.http_server import app, launch_server, _global_state
+from sglang.srt.entrypoints.http_server import _global_state, app, launch_server
 from sglang.srt.managers.io_struct import (
     UpdateWeightFromDiskReqInput,
     UpdateWeightsFromTensorReqInput,
@@ -15,27 +15,8 @@ from prime_rl.inference.backends.base import BaseBackend
 from prime_rl.inference.config import InferenceConfig
 
 
-def _translate_config(config: InferenceConfig) -> list[str]:
-    args: list[str] = ["--model-path", config.model.name, "--port", str(config.server.port)]
-    if config.server.host:
-        args += ["--host", config.server.host]
-    if config.model.dtype:
-        args += ["--dtype", config.model.dtype]
-    if config.model.max_model_len is not None:
-        args += ["--context-length", str(config.model.max_model_len)]
-    if config.model.trust_remote_code:
-        args.append("--trust-remote-code")
-    args += ["--tp-size", str(config.parallel.tp), "--dp-size", str(config.parallel.dp)]
-    if config.seed is not None:
-        args += ["--random-seed", str(config.seed)]
-    if config.model.tool_call_parser:
-        args += ["--tool-call-parser", config.model.tool_call_parser]
-    return args
-
-
 def server(config: InferenceConfig, sglang_args: list[str]):
-    argv = _translate_config(config) + sglang_args
-    server_args = prepare_server_args(argv)
+    server_args = prepare_server_args(sglang_args)
 
     def _remove_route(path: str):
         for r in list(app.router.routes):

--- a/src/prime_rl/inference/server.py
+++ b/src/prime_rl/inference/server.py
@@ -1,5 +1,5 @@
-from prime_rl.inference.backends.vllm import VLLMBackend
 from prime_rl.inference.backends.sglang import SGLangBackend
+from prime_rl.inference.backends.vllm import VLLMBackend
 from prime_rl.inference.config import InferenceConfig
 from prime_rl.utils.pydantic_config import parse_argv
 
@@ -9,6 +9,8 @@ BACKENDS = {"vllm": VLLMBackend, "sglang": SGLangBackend}
 def main():
     config = parse_argv(InferenceConfig, allow_extras=True)
     server_type = config.server.server_type
+    if server_type == "sglang":
+        config.set_unknown_args(config.to_sglang() + config.get_unknown_args())
     backend_cls = BACKENDS.get(server_type)
     if backend_cls is None:
         raise ValueError(f"Unsupported server type: {server_type}")


### PR DESCRIPTION
## Summary
- extend inference config with pipeline parallel, quantization, static memory fraction, and logprob start length fields
- add `to_sglang` for translating config to sglang CLI args
- route sglang translation through server and simplify backend

## Testing
- `pre-commit run --files src/prime_rl/inference/config.py src/prime_rl/inference/backends/sglang.py src/prime_rl/inference/server.py`
- `pytest tests/unit/test_config.py` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68c594fd35e8832e967d11e9923052b7