### PR TITLE
feat: add sglang logit transforms

### DIFF
--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -41,6 +41,11 @@ class ClientConfig(BaseConfig):
         ),
     ] = "vllm"
 
+    apply_sampling_transforms: Annotated[
+        bool,
+        Field(description="Apply temp/top_p to SGLang logits."),
+    ] = True
+
     @model_validator(mode="after")
     def auto_setup_server_type(self):
         if self.base_url == "https://api.openai.com/v1":


### PR DESCRIPTION
## Summary
- add `apply_sampling_transforms` helper to process SGLang logits
- allow opting out via `ClientConfig.apply_sampling_transforms`
- use helper during eval when backend is SGLang

## Testing
- `ruff check .`
- `pytest -q` *(fails: proxy errors and missing NVIDIA driver)*

------
https://chatgpt.com/codex/tasks/task_e_68c597a4497c832e8cadc83bb375a661