### PR TITLE
feat: allow sglang backend

### DIFF
--- a/src/prime_rl/orchestrator/client.py
+++ b/src/prime_rl/orchestrator/client.py
@@ -62,7 +62,7 @@ async def check_has_model(client: AsyncOpenAI, model_name: str) -> None:
 
 
 async def update_weights(client: AsyncOpenAI, path: Path, step: int) -> None:
-    """Make a HTTP post request to the vLLM server to update the weights."""
+    """POST to update backend weights."""
     logger = get_logger()
     url = str(client.base_url)[:-4] + "/update_weights"
     try:
@@ -75,7 +75,7 @@ async def update_weights(client: AsyncOpenAI, path: Path, step: int) -> None:
 
 
 async def reload_weights(client: AsyncOpenAI) -> None:
-    """Make a HTTP post request to the vLLM server to reload weights (reset to base model)."""
+    """POST to reset backend weights."""
     logger = get_logger()
     url = str(client.base_url)[:-4] + "/reload_weights"
     try:

--- a/src/prime_rl/orchestrator/config.py
+++ b/src/prime_rl/orchestrator/config.py
@@ -7,7 +7,7 @@ from prime_rl.orchestrator.advantage import AdvantageType
 from prime_rl.utils.config import LogConfig, ModelConfig, WandbMonitorConfig
 from prime_rl.utils.pydantic_config import BaseConfig, BaseSettings
 
-ServerType = Literal["vllm", "openai"]
+ServerType = Literal["vllm", "sglang", "openai"]
 
 
 class ClientConfig(BaseConfig):
@@ -37,7 +37,7 @@ class ClientConfig(BaseConfig):
     server_type: Annotated[
         ServerType,
         Field(
-            description="Type of inference server that the client is connected to. Can be 'vllm' or 'openai'. Defaults to vLLM, which is our default client for training.",
+            description="Type of inference server. 'vllm', 'sglang', or 'openai'. Defaults to vLLM, our training default.",
         ),
     ] = "vllm"
 

--- a/src/prime_rl/orchestrator/orchestrator.py
+++ b/src/prime_rl/orchestrator/orchestrator.py
@@ -58,7 +58,6 @@ async def orchestrate(config: OrchestratorConfig):
         )
 
     # Setup client
-    assert config.client.server_type == "vllm", "Orchestrator only supports vLLM server type."
     logger.info(
         f"Initializing OpenAI client (base_url={config.client.base_url}, api_key_var={config.client.api_key_var}, server_type={config.client.server_type})"
     )


### PR DESCRIPTION
## Summary
- add `sglang` to client server enum
- drop vLLM-only assertion in orchestrator
- keep weight update endpoints backend-agnostic

## Testing
- `PYTHONPATH=src pytest -q` *(fails: No module named 'torch', 'datasets', 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68c59c1fb438832e9d4c19b471833dfd